### PR TITLE
New: Allow unitless or percentage leading values

### DIFF
--- a/.changeset/lovely-ways-peel.md
+++ b/.changeset/lovely-ways-peel.md
@@ -1,0 +1,6 @@
+---
+'tailwindcss-capsize': minor
+---
+
+Allow unitless or percentage-based leading values  
+Uses the inherited `font-size` to determine pixel `line-height` value.

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -7,7 +7,7 @@ import { PluginOptions } from '../src/types'
 
 const generatePluginCss = async (
     config: Record<string, unknown>,
-    pluginOptions: PluginOptions
+    pluginOptions: PluginOptions,
 ) => {
     return postcss(
         tailwindcss(
@@ -25,14 +25,6 @@ const generatePluginCss = async (
                                 lineGap: 0,
                                 unitsPerEm: 2816,
                             },
-                        },
-                        fontSize: {
-                            sm: '14px',
-                            md: '1.5rem',
-                        },
-                        lineHeight: {
-                            sm: '20px',
-                            md: '2.5rem',
                         },
                     },
                     corePlugins: false,
@@ -70,8 +62,22 @@ expect.extend({
 })
 
 describe('Plugin', () => {
-    it('generates utility classes with a default root size', () => {
-        return generatePluginCss({}, {}).then((css) => {
+    it('generates utility classes with a default root size', async () => {
+        return generatePluginCss(
+            {
+                theme: {
+                    fontSize: {
+                        sm: '14px',
+                        md: '1.5rem',
+                    },
+                    lineHeight: {
+                        sm: '20px',
+                        md: '2.5rem',
+                    },
+                },
+            },
+            {},
+        ).then((css) => {
             // eslint-disable-next-line
             // @ts-ignore
             expect(css).toMatchCss(`
@@ -198,8 +204,22 @@ describe('Plugin', () => {
         })
     })
 
-    it('generates utility classes with a custom root size', () => {
-        return generatePluginCss({}, { rootSize: 12 }).then((css) => {
+    it('generates utility classes with a custom root size', async () => {
+        return generatePluginCss(
+            {
+                theme: {
+                    fontSize: {
+                        sm: '14px',
+                        md: '1.5rem',
+                    },
+                    lineHeight: {
+                        sm: '20px',
+                        md: '2.5rem',
+                    },
+                },
+            },
+            { rootSize: 12 },
+        ).then((css) => {
             // eslint-disable-next-line
             // @ts-ignore
             expect(css).toMatchCss(`
@@ -323,6 +343,87 @@ describe('Plugin', () => {
                         height: 0;
                     }
                 `)
+        })
+    })
+
+    it('works with unitless or percentage line-height values', async () => {
+        return generatePluginCss(
+            {
+                theme: {
+                    fontSize: {
+                        sm: '1rem',
+                    },
+                    lineHeight: {
+                        sm: '100%',
+                        md: '1.5',
+                    },
+                },
+            },
+            {},
+        ).then((css) => {
+            // eslint-disable-next-line
+            // @ts-ignore
+            expect(css).toMatchCss(`
+            .font-sans.text-sm.leading-sm.capsize,
+            .font-sans .text-sm.leading-sm.capsize,
+            .font-sans .text-sm .leading-sm.capsize,
+            .text-sm .font-sans.leading-sm.capsize,
+            .text-sm .font-sans .leading-sm.capsize {
+                padding: 0.05px 0;
+              }
+
+              .font-sans.text-sm.leading-sm.capsize::before,
+              .font-sans .text-sm.leading-sm.capsize::before,
+              .font-sans .text-sm .leading-sm.capsize::before,
+              .text-sm .font-sans.leading-sm.capsize::before,
+              .text-sm .font-sans .leading-sm.capsize::before {
+                content: '';
+                margin-top: -0.1395em;
+                display: block;
+                height: 0;
+              }
+
+              .font-sans.text-sm.leading-sm.capsize::after,
+              .font-sans .text-sm.leading-sm.capsize::after,
+              .font-sans .text-sm .leading-sm.capsize::after,
+              .text-sm .font-sans.leading-sm.capsize::after,
+              .text-sm .font-sans .leading-sm.capsize::after {
+                content: '';
+                margin-bottom: -0.1395em;
+                display: block;
+                height: 0;
+              }
+
+              .font-sans.text-sm.leading-md.capsize,
+              .font-sans .text-sm.leading-md.capsize,
+              .font-sans .text-sm .leading-md.capsize,
+              .text-sm .font-sans.leading-md.capsize,
+              .text-sm .font-sans .leading-md.capsize {
+                padding: 0.05px 0;
+              }
+
+              .font-sans.text-sm.leading-md.capsize::before,
+              .font-sans .text-sm.leading-md.capsize::before,
+              .font-sans .text-sm .leading-md.capsize::before,
+              .text-sm .font-sans.leading-md.capsize::before,
+              .text-sm .font-sans .leading-md.capsize::before {
+                content: '';
+                margin-top: -0.3895em;
+                display: block;
+                height: 0;
+              }
+
+              .font-sans.text-sm.leading-md.capsize::after,
+              .font-sans .text-sm.leading-md.capsize::after,
+              .font-sans .text-sm .leading-md.capsize::after,
+              .text-sm .font-sans.leading-md.capsize::after,
+              .text-sm .font-sans .leading-md.capsize::after {
+                content: '';
+                margin-bottom: -0.3895em;
+                display: block;
+                height: 0;
+              }
+            `)
         })
     })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import capsize from 'capsize'
 import plugin from 'tailwindcss/plugin'
 
-import { makeCssSelectors, normalizeValue } from './utils'
 import { PluginOptions } from './types'
+import { makeCssSelectors, normalizeValue } from './utils'
 
 interface FontMetrics {
     ascent: number
@@ -21,16 +21,6 @@ export default plugin.withOptions(({ rootSize = 16 }: PluginOptions) => {
         >
         let lineHeight = theme('lineHeight', {}) as Record<string, string>
         let fontSize = theme('fontSize', {}) as Record<string, string>
-
-        // let leadings = Object.values(lineHeight).filter((leading) => {
-        //     if (lineHeight[leading]) {
-        //         return (
-        //             lineHeight[leading].endsWith('rem') ||
-        //             lineHeight[leading].endsWith('px')
-        //         )
-        //     }
-        // })
-
         let utilities = {} as { [property: string]: any }
 
         Object.keys(fontMetrics).forEach((fontFamily) => {
@@ -39,7 +29,7 @@ export default plugin.withOptions(({ rootSize = 16 }: PluginOptions) => {
             Object.keys(fontSize).forEach((sizeName) => {
                 Object.keys(lineHeight).forEach((leading) => {
                     let fs = normalizeValue(fontSize[sizeName], rootSize)
-                    let lh = normalizeValue(lineHeight[leading], rootSize)
+                    let lh = normalizeValue(lineHeight[leading], rootSize, fs)
 
                     let {
                         '::after': after,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,21 @@
-export function normalizeValue(value: string, root: number): number {
-    let isPixelValue = value.endsWith('px')
-    let isRemValue = value.endsWith('rem')
+export function normalizeValue(
+    value: string,
+    root: number,
+    fs?: number,
+): number {
+    if (value.endsWith('px')) return parseInt(value.replace('px', ''))
+    if (value.endsWith('rem'))
+        return root * parseFloat(value.replace('rem', ''))
 
-    if (isPixelValue) return parseInt(value.replace('px', ''))
-    if (isRemValue) return root * parseFloat(value.replace('rem', ''))
+    let isPercentValue = value.endsWith('%')
+    let isUnitlessValue = /[0-9]$/.test(value)
+
+    if ((isPercentValue || isUnitlessValue) && fs) {
+        let multiplier = isPercentValue
+            ? parseInt(value.replace('%', '')) / 100
+            : parseFloat(value)
+        return fs * multiplier
+    }
 
     return parseInt(value)
 }


### PR DESCRIPTION
Uses the inherited `font-size` to determine pixel `line-height` value.

Closes #19 