### PR TITLE
Fix: Better default options assignment

### DIFF
--- a/.changeset/large-bikes-enjoy.md
+++ b/.changeset/large-bikes-enjoy.md
@@ -1,0 +1,10 @@
+---
+'tailwindcss-capsize': patch
+---
+
+Fix issue requiring an empty options object to be passed in
+
+```diff
+- require('tailwindcss-capsize')({})
++ require('tailwindcss-capsize')
+```

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Test
-        run: npm test -- --ci --coverage --maxWorkers=2
-
       - name: Build
         run: npm run build
+
+      - name: Test
+        run: npm test -- --ci --coverage --maxWorkers=2

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -7,7 +7,7 @@ import { PluginOptions } from '../src/types'
 
 const generatePluginCss = async (
     config: Record<string, unknown>,
-    pluginOptions: PluginOptions,
+    pluginOptions?: PluginOptions | undefined,
 ) => {
     return postcss(
         tailwindcss(
@@ -76,7 +76,6 @@ describe('Plugin', () => {
                     },
                 },
             },
-            {},
         ).then((css) => {
             // eslint-disable-next-line
             // @ts-ignore
@@ -359,7 +358,6 @@ describe('Plugin', () => {
                     },
                 },
             },
-            {},
         ).then((css) => {
             // eslint-disable-next-line
             // @ts-ignore

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ interface FontMetrics {
     capHeight: number
 }
 
-export default plugin.withOptions(({ rootSize = 16 }: PluginOptions) => {
+export default plugin.withOptions<PluginOptions | undefined>(({ rootSize = 16 } = {}) => {
     return function ({ addUtilities, theme }) {
         /** @todo Improve these types maybe? */
         let fontMetrics = theme('fontMetrics', {}) as Record<

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,46 +12,52 @@ interface FontMetrics {
     capHeight: number
 }
 
-export default plugin.withOptions<PluginOptions | undefined>(({ rootSize = 16 } = {}) => {
-    return function ({ addUtilities, theme }) {
-        /** @todo Improve these types maybe? */
-        let fontMetrics = theme('fontMetrics', {}) as Record<
-            string,
-            FontMetrics
-        >
-        let lineHeight = theme('lineHeight', {}) as Record<string, string>
-        let fontSize = theme('fontSize', {}) as Record<string, string>
-        let utilities = {} as { [property: string]: any }
+export default plugin.withOptions<PluginOptions | undefined>(
+    ({ rootSize = 16 } = {}) => {
+        return function ({ addUtilities, theme }) {
+            /** @todo Improve these types maybe? */
+            let fontMetrics = theme('fontMetrics', {}) as Record<
+                string,
+                FontMetrics
+            >
+            let lineHeight = theme('lineHeight', {}) as Record<string, string>
+            let fontSize = theme('fontSize', {}) as Record<string, string>
+            let utilities = {} as { [property: string]: any }
 
-        Object.keys(fontMetrics).forEach((fontFamily) => {
-            let fontConfig = fontMetrics[fontFamily]
+            Object.keys(fontMetrics).forEach((fontFamily) => {
+                let fontConfig = fontMetrics[fontFamily]
 
-            Object.keys(fontSize).forEach((sizeName) => {
-                Object.keys(lineHeight).forEach((leading) => {
-                    let fs = normalizeValue(fontSize[sizeName], rootSize)
-                    let lh = normalizeValue(lineHeight[leading], rootSize, fs)
+                Object.keys(fontSize).forEach((sizeName) => {
+                    Object.keys(lineHeight).forEach((leading) => {
+                        let fs = normalizeValue(fontSize[sizeName], rootSize)
+                        let lh = normalizeValue(
+                            lineHeight[leading],
+                            rootSize,
+                            fs,
+                        )
 
-                    let {
-                        '::after': after,
-                        '::before': before,
-                        padding,
-                    } = capsize({
-                        fontMetrics: fontConfig,
-                        fontSize: fs,
-                        leading: lh,
+                        let {
+                            '::after': after,
+                            '::before': before,
+                            padding,
+                        } = capsize({
+                            fontMetrics: fontConfig,
+                            fontSize: fs,
+                            leading: lh,
+                        })
+
+                        utilities[
+                            makeCssSelectors(fontFamily, sizeName, leading)
+                        ] = {
+                            padding,
+                            '&::before': before,
+                            '&::after': after,
+                        }
                     })
-
-                    utilities[
-                        makeCssSelectors(fontFamily, sizeName, leading)
-                    ] = {
-                        padding,
-                        '&::before': before,
-                        '&::after': after,
-                    }
                 })
             })
-        })
 
-        addUtilities(utilities, {})
-    }
-})
+            addUtilities(utilities, {})
+        }
+    },
+)


### PR DESCRIPTION
Make it so an empty options object isn't required to be passed in in
order to use the default options.
