### PR TITLE
Fix: Remove unit from `--font-size-px` custom property

### DIFF
--- a/.changeset/violet-bikes-sing.md
+++ b/.changeset/violet-bikes-sing.md
@@ -1,0 +1,6 @@
+---
+'tailwindcss-capsize': patch
+---
+
+Remove unit from `--font-size-px` custom property
+Fixes issue with `calc()` functions not working correctly.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > A TailwindCSS plugin that generates leading-trim utility classes using [Capsize](https://github.com/seek-oss/capsize).
 
 ```bash
-$ npm install --save-dev tailwindcss-capsize
+npm install --save-dev tailwindcss-capsize
 ```
 
 ## leading-trim?
@@ -26,7 +26,7 @@ This plugin requires a `fontMetrics` key added to your Tailwind theme. It should
 }
 ```
 
-These values can be determined by using the [Capsize website](https://seek-oss.github.io/capsize/), by using [fontkit](https://github.com/foliojs/fontkit), or some other means.
+These values can be determined by using the [Capsize website](https://seek-oss.github.io/capsize/), by using [fontkit](https://github.com/foliojs/fontkit), by using [FontDrop!](https://fontdrop.info), or some other means.
 
 ### A full example
 
@@ -58,9 +58,17 @@ module.exports = {
 
 The new `.capsize` utility class should be applied to the _direct parent_ element surrounding a text node. This class requires `font-family`, `font-size`, and `line-height` utilities to be applied at some point above it in the cascade in order for the required custom properties to be available.
 
+```html
+<!-- Example using default TailwindCSS config -->
+
+<p class="font-sans text-base leading-none capsize">Lorem ipsum dolor</p>
+```
+
 ## Options
 
 ### rootSize
+
+type: `number` (optional, default: `16`)
 
 The plugin assumes a root font-size of `16px` when converting from rem values. To use a different value, pass it in (without units) to the plugin options.
 
@@ -70,6 +78,8 @@ require('tailwindcss-capsize')({ rootSize: 12 })
 
 ### className
 
+type: `string` (optional, default: `'capsize'`)
+
 The default `.capsize` utility class can be replaced with a custom class name if preferred.
 
 ```js
@@ -77,6 +87,8 @@ require('tailwindcss-capsize')({ className: 'leading-trim' })
 ```
 
 ### mode
+
+type: `'modern' | 'classic'` (optional, default: `'modern'`)
 
 By default the plugin replaces the `fontFamily`, `fontSize`, and `lineHeight` core plugins, adding custom properties to the output of each which are used in the `calc()` expressions in the utility class.
 
@@ -97,10 +109,33 @@ If you need to support browsers that don’t support custom properties, setting 
 require('tailwindcss-capsize')({ mode: 'classic' })
 ```
 
+## Tips and tricks
+
+### Text truncation and line clamping
+
+Sometimes an interface calls for truncating text to a single line or clamping text to a specified number of lines. Applying these methods to the same element that the default `.capsize` class is applied to will cause issues since the class assigns pseudo `::before` and `::after` elements to that element.
+
+```html
+<!-- ❌ Does NOT work -->
+
+<p class="font-sans text-base leading-none capsize truncate">
+    Text to be truncated to a single line
+</p>
+```
+
+To solve this, a child element to the element with the `.capsize` class should wrap the text. This element should receive the styling to truncate or line clamp.
+
+```html
+<!-- ✅ Does work! -->
+
+<p class="font-sans text-base leading-none capsize">
+    <span class="truncate"> Text to be truncated to a single line </span>
+</p>
+```
+
 ## Related
 
-[🔡 tailwindcss-opentype](https://github.com/stormwarning/tailwindcss-opentype)  
-Utility classes for advanced typographic features.
+[🔡 tailwindcss-opentype](https://github.com/stormwarning/tailwindcss-opentype): Utility classes for advanced typographic features.
 
 [npm-url]: https://www.npmjs.com/package/tailwindcss-capsize
 [npm-img]: https://img.shields.io/npm/v/tailwindcss-capsize.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This plugin requires a `fontMetrics` key added to your Tailwind theme. It should
 }
 ```
 
-These values can be determined by using the [Capsize website](https://seek-oss.github.io/capsize/), by using [fontkit](https://github.com/foliojs/fontkit), by using [FontDrop!](https://fontdrop.info), or some other means.
+These values can be determined by using the [Capsize website](https://seek-oss.github.io/capsize/), [fontkit](https://github.com/foliojs/fontkit), [FontDrop!](https://fontdrop.info), or some other means.
 
 ### A full example
 
@@ -68,7 +68,7 @@ The new `.capsize` utility class should be applied to the _direct parent_ elemen
 
 ### rootSize
 
-type: `number` (optional, default: `16`)
+#### type: `number` (optional, default: `16`)
 
 The plugin assumes a root font-size of `16px` when converting from rem values. To use a different value, pass it in (without units) to the plugin options.
 
@@ -78,7 +78,7 @@ require('tailwindcss-capsize')({ rootSize: 12 })
 
 ### className
 
-type: `string` (optional, default: `'capsize'`)
+#### type: `string` (optional, default: `'capsize'`)
 
 The default `.capsize` utility class can be replaced with a custom class name if preferred.
 
@@ -88,7 +88,7 @@ require('tailwindcss-capsize')({ className: 'leading-trim' })
 
 ### mode
 
-type: `'modern' | 'classic'` (optional, default: `'modern'`)
+#### type: `'modern' | 'classic'` (optional, default: `'modern'`)
 
 By default the plugin replaces the `fontFamily`, `fontSize`, and `lineHeight` core plugins, adding custom properties to the output of each which are used in the `calc()` expressions in the utility class.
 
@@ -129,13 +129,13 @@ To solve this, a child element to the element with the `.capsize` class should w
 <!-- ✅ Does work! -->
 
 <p class="font-sans text-base leading-none capsize">
-    <span class="truncate"> Text to be truncated to a single line </span>
+    <span class="truncate">Text to be truncated to a single line</span>
 </p>
 ```
 
 ## Related
 
-[🔡 tailwindcss-opentype](https://github.com/stormwarning/tailwindcss-opentype): Utility classes for advanced typographic features.
+[🔡 tailwindcss-opentype](https://github.com/stormwarning/tailwindcss-opentype) — Utility classes for advanced typographic features.
 
 [npm-url]: https://www.npmjs.com/package/tailwindcss-capsize
 [npm-img]: https://img.shields.io/npm/v/tailwindcss-capsize.svg?style=flat-square

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -86,12 +86,12 @@ describe('Plugin', () => {
                     }
 
                     .text-sm {
-                      --font-size-px: 14px;
+                      --font-size-px: 14;
                       font-size: 14px;
                     }
 
                     .text-md {
-                      --font-size-px: 24px;
+                      --font-size-px: 24;
                       font-size: 1.5rem;
                     }
 
@@ -146,12 +146,12 @@ describe('Plugin', () => {
                       }
 
                       .sm\\:text-sm {
-                        --font-size-px: 14px;
+                        --font-size-px: 14;
                         font-size: 14px;
                       }
 
                       .sm\\:text-md {
-                        --font-size-px: 24px;
+                        --font-size-px: 24;
                         font-size: 1.5rem;
                       }
 
@@ -209,12 +209,12 @@ describe('Plugin', () => {
                     }
 
                     .text-sm {
-                      --font-size-px: 14px;
+                      --font-size-px: 14;
                       font-size: 14px;
                     }
 
                     .text-md {
-                      --font-size-px: 18px;
+                      --font-size-px: 18;
                       font-size: 1.5rem;
                     }
 
@@ -294,7 +294,7 @@ describe('Plugin', () => {
                     }
 
                     .text-sm {
-                      --font-size-px: 16px;
+                      --font-size-px: 16;
                       font-size: 1rem;
                     }
 
@@ -380,7 +380,7 @@ describe('Plugin', () => {
                     }
 
                     .text-sm {
-                      --font-size-px: 16px;
+                      --font-size-px: 16;
                       font-size: 1rem;
                     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tailwindcss-capsize",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tailwindcss-capsize",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "@capsizecss/core": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-capsize",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "TailwindCSS leading-trim utility classes.",
   "keywords": [
     "tailwindcss",
@@ -13,6 +13,9 @@
   "repository": "stormwarning/tailwindcss-capsize",
   "license": "ISC",
   "author": "Jeff Nelson (https://tidaltheory.io)",
+  "contributors": [
+    "Jesse McLean (https://builtbyfield.com)"
+  ],
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-capsize",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "description": "TailwindCSS leading-trim utility classes.",
   "keywords": [
     "tailwindcss",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -171,6 +171,8 @@ export default plugin.withOptions<Partial<PluginOptions>>(
                                 fontSize,
                                 rootSize,
                             )
+                            // eslint-disable-next-line no-console
+                            console.log(fontSizeActual)
                             let { lineHeight, letterSpacing } = (isPlainObject(
                                 options,
                             )
@@ -181,7 +183,7 @@ export default plugin.withOptions<Partial<PluginOptions>>(
                                   }) as FontSizeOptions
 
                             return {
-                                '--font-size-px': fontSizeActual,
+                                '--font-size-px': String(fontSizeActual),
                                 'font-size': fontSize,
                                 ...(lineHeight === undefined
                                     ? {}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -171,8 +171,6 @@ export default plugin.withOptions<Partial<PluginOptions>>(
                                 fontSize,
                                 rootSize,
                             )
-                            // eslint-disable-next-line no-console
-                            console.log(fontSizeActual)
                             let { lineHeight, letterSpacing } = (isPlainObject(
                                 options,
                             )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
-    "rootDir": "./",
+    "rootDir": "./src",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
This pull request solves an issue (#129) where the `fontSizeActual` variable in the `plugin.ts` file is passed as a `number` and `postcss-js` (which TailwindCSS uses under the hood to parse plugins) converts this to a pixel value.

This creates an issue with the various CSS `calc`s that use the `--font-size-px` CSS custom property since certain units cannot be mixed (addition `+` and subtraction `-` in this use case).

By wrapping `fontSizeActual` with `String()` and editing the tests to check that the values for `--font-size-px` are truly flat values (i.e. `--font-size-px: 16;`, not `--font-size-px: 16px;`), the plugin works correctly now in `mode: 'modern'`.

In addition to this fix, this pull request introduces some improvements to the README.md and upgrades the package to version 3.0.1.