### PR TITLE
Handle object or undefined values

### DIFF
--- a/.changeset/sad-rabbits-remain.md
+++ b/.changeset/sad-rabbits-remain.md
@@ -1,0 +1,5 @@
+---
+'tailwindcss-capsize': patch
+---
+
+Handle anomalous values from Tailwind language server

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -77,8 +77,14 @@ const thisPlugin: PluginType = createPlugin.withOptions<CapsizePluginOptions>(
 			// Font-size
 			matchUtilities(
 				{
-					// @ts-expect-error -- Extra custom properties mismatches base type.
 					text(value: string | [string, string | FontSizeOptions]) {
+						/**
+						 * For some reason, tailwindcss-intellisense passes
+						 * object and undefined values in here, so we handle
+						 * those cases so it doesn't break IDE plugins.
+						 */
+						if (!value || isPlainObject(value)) return {}
+
 						let [fontSize, options] = Array.isArray(value) ? value : [value]
 						let fontSizeActual = normalizeValue(fontSize, rootSize)
 						let { lineHeight } = (
@@ -87,7 +93,7 @@ const thisPlugin: PluginType = createPlugin.withOptions<CapsizePluginOptions>(
 
 						return {
 							'--font-size-px': String(fontSizeActual),
-							...lineHeightProperties(lineHeight, rootSize),
+							...(lineHeight ? lineHeightProperties(lineHeight, rootSize) : {}),
 						}
 					},
 				},
@@ -100,11 +106,10 @@ const thisPlugin: PluginType = createPlugin.withOptions<CapsizePluginOptions>(
 			// Line-height
 			matchUtilities(
 				{
-					// @ts-expect-error -- Extra custom properties mismatches base type.
 					leading(value: string | string[]) {
 						let lineHeight = normalizeThemeValue('lineHeight', value) as string
 
-						return lineHeightProperties(lineHeight, rootSize)
+						return lineHeight ? lineHeightProperties(lineHeight, rootSize) : {}
 					},
 				},
 				{

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -83,9 +83,7 @@ export function round(value: number) {
  * Takes a theme value for lineHeight and returns the `--line-height-offset`
  * custom property.
  */
-export function lineHeightProperties(lineHeight?: string, rootSize = 16) {
-	if (lineHeight === undefined) return {}
-
+export function lineHeightProperties(lineHeight: string, rootSize = 16) {
 	let lineHeightActual = isRelativeValue(lineHeight)
 		? `calc(${getRelativeValue(lineHeight).toString()} * var(--font-size-px))`
 		: normalizeValue(lineHeight, rootSize).toString()


### PR DESCRIPTION
`tailwindcss-intellisense` passes in object and undefined values so now
this handles those cases so things don't break.

Fixes #260 
